### PR TITLE
Force wrapping resource URIs

### DIFF
--- a/templates/_bootstrap-layout.jade
+++ b/templates/_bootstrap-layout.jade
@@ -63,6 +63,11 @@ html
                         code
                             color #c7254e
                             background-color transparent
+                            white-space pre-wrap
+                            white-space -moz-pre-wrap
+                            white-space -pre-wrap
+                            white-space -o-pre-wrap
+                            word-wrap break-word
                         h3
                             margin-top 10px
                             margin-bottom 10px

--- a/templates/_bootstrap-mixins.jade
+++ b/templates/_bootstrap-mixins.jade
@@ -131,7 +131,8 @@ mixin ResourceGroup(resourceGroup, getButtonClass, multipage)
                     section.panel(class=panelClass, id="#{slug(resourceGroup.name)}-#{slug(resource.name)}-#{slug(action.method)}")
                         .panel-heading
                             if action.name
-                                span.pull-right(style="text-transform: lowercase")= action.name
+                                div(style="float:right")
+                                    span(style="text-transform: lowercase")= action.name
                             case action.method
                                 when 'POST': - var btnClass = 'btn-success'
                                 when 'GET': - var btnClass = 'btn-' + getButtonClass
@@ -139,9 +140,10 @@ mixin ResourceGroup(resourceGroup, getButtonClass, multipage)
                                 when 'PATCH': - var btnClass = 'btn-warning'
                                 when 'DELETE': - var btnClass = 'btn-danger'
                                 default: - var btnClass = 'btn-default'
-                            a.btn.btn-xs(class=btnClass, href="##{(multipage ? 'page:' + slug(resourceGroup.name) + ',header:' : '')}#{slug(resourceGroup.name)}-#{slug(resource.name)}-#{slug(action.method)}")= action.method
-                            | &nbsp;
-                            code= resource.uriTemplate
+                            div(style="float:left")
+                                a.btn.btn-xs(class=btnClass, href="##{(multipage ? 'page:' + slug(resourceGroup.name) + ',header:' : '')}#{slug(resourceGroup.name)}-#{slug(resource.name)}-#{slug(action.method)}")= action.method
+                            div(style="overflow:hidden")
+                                code= resource.uriTemplate
                         if action.description
                             .panel-body!= markdown(action.description)
 

--- a/templates/cyborg.jade
+++ b/templates/cyborg.jade
@@ -59,6 +59,11 @@ block styles
                 code
                     color white
                     background-color transparent
+                    white-space pre-wrap
+                    white-space -moz-pre-wrap
+                    white-space -pre-wrap
+                    white-space -o-pre-wrap
+                    word-wrap break-word
                 h3
                     margin-top 10px
                     margin-bottom 10px

--- a/templates/flatly.jade
+++ b/templates/flatly.jade
@@ -58,6 +58,11 @@ block styles
                 code
                     color white
                     background-color transparent
+                    white-space pre-wrap
+                    white-space -moz-pre-wrap
+                    white-space -pre-wrap
+                    white-space -o-pre-wrap
+                    word-wrap break-word
                 h3
                     margin-top 10px
                     margin-bottom 10px

--- a/templates/slate.jade
+++ b/templates/slate.jade
@@ -60,6 +60,11 @@ block styles
                 code
                     color black
                     background-color transparent
+                    white-space pre-wrap
+                    white-space -moz-pre-wrap
+                    white-space -pre-wrap
+                    white-space -o-pre-wrap
+                    word-wrap break-word
                 h3
                     margin-top 10px
                     margin-bottom 10px


### PR DESCRIPTION
When resourece URIs becomes too large they extend beyond the containers of the page. Templates have been modified to force wrap the URI when it is necessary.

This solves the problem in issue #13
