### PR TITLE
Fixes navigation panel blowout when routes have long descriptions.

### DIFF
--- a/templates/_bootstrap-layout.jade
+++ b/templates/_bootstrap-layout.jade
@@ -88,7 +88,7 @@ html
 
                     #nav
                         margin-top 38px
-                        min-width 255px
+                        max-width 255px
                         top 0
                         bottom 0
                         padding-right 12px


### PR DESCRIPTION
When a route has a very long description the default templates cause the navigation panel and content panel to overlap.

Before:
![screen shot 2014-04-09 at 9 36 00 am](https://cloud.githubusercontent.com/assets/4449223/2658187/590ef66a-c005-11e3-8064-ec975f8825cc.png)

Changing the min-width to max-width fixes this problem.

After:
![screen shot 2014-04-09 at 9 36 26 am](https://cloud.githubusercontent.com/assets/4449223/2658197/71087b4c-c005-11e3-8756-932360942f59.png)

My thanks to @PN-mruiz for the CSS assist!
