### PR TITLE
Adding protocol-agnostic SRC for knockout

### DIFF
--- a/templates/_bootstrap-mixins.jade
+++ b/templates/_bootstrap-mixins.jade
@@ -211,7 +211,7 @@ mixin Content(getButtonClass, multipage)
 
 mixin Multipage()
     //- Multi-page support through Knockout.js
-    script(src="http://cdnjs.cloudflare.com/ajax/libs/knockout/3.0.0/knockout-min.js")
+    script(src="//cdnjs.cloudflare.com/ajax/libs/knockout/3.0.0/knockout-min.js")
     script
         :coffee
             class App


### PR DESCRIPTION
This prevents knockout from being blocked due to a mixed content warning (when loading the docs over HTTPS).
