### PR TITLE
Package main was pointing to incorrect file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aglio",
   "version": "1.14.0",
   "description": "An API Blueprint renderer with theme support",
-  "main": "lib/main.js",
+  "main": "src/main.coffee",
   "bin": {
     "aglio": "./bin/aglio.js"
   },


### PR DESCRIPTION
At some point, a switch was made to `coffee` and the files moved from `lib` to `src`, but the package `main` property was not updated accordingly. This fixes this problem. This was causing issues where other packages trying to run the `aglio` command would fail with the following error:

```
Loading "aglio.js" tasks...ERROR
>> Error: Cannot find module 'aglio'
```
