### PR TITLE
Adding a proper exit code

### DIFF
--- a/bin/aglio.js
+++ b/bin/aglio.js
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 
-require('../lib/bin').run();
+require('../lib/bin').run(null, function(err){
+	if(err){
+		process.exit(1);
+	}
+});


### PR DESCRIPTION
If the application errored, it now exits with 1 instead of 0. Closes #38
