### PR TITLE
Fix reading from stdin to handle when chunk is null

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -114,4 +114,6 @@ exports.renderFile = (inputFile, outputFile, options, done) ->
     else
         process.stdin.setEncoding 'utf-8'
         process.stdin.on 'readable', ->
-            render process.stdin.read()
+            chunk = process.stdin.read()
+            if chunk?
+                render chunk


### PR DESCRIPTION
Looks like `process.stdin.read()` will return `null` if there is no data available (http://nodejs.org/api/stream.html#stream_readable_read_size) and the call to `render` will fail if `null` is passed in.
