### PR TITLE
change precedence of nav labeling to consider the action name first

### DIFF
--- a/templates/_bootstrap-mixins.jade
+++ b/templates/_bootstrap-mixins.jade
@@ -122,7 +122,7 @@ mixin ResourceGroup(resourceGroup, getButtonClass, multipage)
                 != markdown(resourceGroup.description)
             each resource in resourceGroup.resources
                 h4(id="#{slug(resourceGroup.name)}-#{slug(resource.name)}")
-                    = resource.name || 'Resources'
+                    = resource.actions[0] != null ? resource.actions[0].name : resource.name || 'Resources'
                     | &nbsp;
                     a(href="##{(multipage ? 'page:' + slug(resourceGroup.name) + ',header:' : '')}#{slug(resourceGroup.name)}-#{slug(resource.name)}")
                         i.fa.fa-link

--- a/templates/_bootstrap-mixins.jade
+++ b/templates/_bootstrap-mixins.jade
@@ -28,7 +28,7 @@ mixin Nav(multipage, collapsible)
                                 a.list-group-item(href="##{multipage ? 'page:' + slug(resourceGroup.name) + ',header:' : ''}#{slug(resourceGroup.name)}-#{slug(resource.name)}", style="border-top-left-radius: 0; border-top-right-radius: 0")
                                     - var action = resource.actions[0]
                                     +Icon(action.method)
-                                    = resource.name || action.name || action.method + ' ' + resource.uriTemplate
+                                    = action.name || resource.name || action.method + ' ' + resource.uriTemplate
             each meta in api.metadata
                 if meta.name == 'HOST'
                     p(style="text-align: center; word-wrap: break-word;")


### PR DESCRIPTION
This pull changes the order in which names are considered when building the nav, so that custom action names defined in the blueprint template are used before the generic resource name.

In the example below, before the change the nav would simply read "User", but after the change it would instead read "Current User", which is the more specific text provided for that method.

```markdown
# Group Users
Methods for interacting with users.

## User [/user]

### Current User [GET]
Get the user information for the user authenticated with the request.

+ Response 200
```
