### PR TITLE
Try using new MSON-like syntax for parameters

### DIFF
--- a/example.md
+++ b/example.md
@@ -202,7 +202,7 @@ A list of users
     + joinedAfter: `2011-01-01` (string, optional, ) - Search by join date
     + sort: `joined` (string, optional) - Which field to sort by
         + Default: `name`
-        + Values
+        + Members
             + `name`
             + `joined`
             + `-joined`

--- a/example.md
+++ b/example.md
@@ -98,7 +98,7 @@ Note description
 
 + Parameters
 
-    + id (required, string, `68a5sdf67`) ... The note ID
+    + id: `68a5sdf67` (required, string) - The note ID
 
 + Model
 

--- a/example.md
+++ b/example.md
@@ -197,11 +197,11 @@ A list of users
 
 + Parameters
 
-    + name (optional, string, `alice`) ... Search for a user by name
-    + joinedBefore (optional, string, `2011-01-01`) ... Search by join date
-    + joinedAfter (optional, string, `2011-01-01`) ... Search by join date
-    + sort = `name` (optional, string, `joined`) ... Which field to sort by
-
+    + name: `alice` (string, optional) - Search for a user by name
+    + joinedBefore: `2011-01-01` (string, optional) - Search by join date
+    + joinedAfter: `2011-01-01` (string, optional, ) - Search by join date
+    + sort: `joined` (string, optional) - Which field to sort by
+        + Default: `name`
         + Values
             + `name`
             + `joined`
@@ -212,9 +212,9 @@ A list of users
             + `-location`
             + `plan`
             + `-plan`
-
-    + limit = `10` (optional, integer, `25`) ... The maximum number of users to return, up to `50`
-
+    + limit: `25` (integer, optional) ... The maximum number of users to return, up to `50`
+      + Default: `10`
+    
 + Model
 
     + Headers


### PR DESCRIPTION
Doesn't seem to work locally, I get:

```
>> Line 203: ignoring unrecognized block (warning code 5)
```

Since I started this branch I noticed that Apiary itself also errors, so I guess there is some new MSON-lish approach to this.

I'll go ask them what is going on, then update this PR accordingly. 