### PR TITLE
Use the actions uriTemplate if it exists

### DIFF
--- a/templates/_bootstrap-mixins.jade
+++ b/templates/_bootstrap-mixins.jade
@@ -23,12 +23,12 @@ mixin Nav(multipage, collapsible)
                                     a.list-group-item(href="##{multipage ? 'page:' + slug(resourceGroup.name) + ',header:' : ''}#{slug(resourceGroup.name)}-#{slug(resource.name)}-#{slug(action.method)}", style="border-top-left-radius: 0; border-top-right-radius: 0")
                                         +Icon(action.method)
                                         span.indent
-                                            = action.name || action.method + ' ' + resource.uriTemplate
+                                            = action.name || action.method + ' ' + (action.attributes.uriTemplate || resource.uriTemplate)
                             else
                                 a.list-group-item(href="##{multipage ? 'page:' + slug(resourceGroup.name) + ',header:' : ''}#{slug(resourceGroup.name)}-#{slug(resource.name)}", style="border-top-left-radius: 0; border-top-right-radius: 0")
                                     - var action = resource.actions[0]
                                     +Icon(action.method)
-                                    = resource.name || action.name || action.method + ' ' + resource.uriTemplate
+                                    = resource.name || action.name || action.method + ' ' + (action.attributes.uriTemplate || resource.uriTemplate)
             each meta in api.metadata
                 if meta.name == 'HOST'
                     p(style="text-align: center; word-wrap: break-word;")
@@ -180,7 +180,7 @@ mixin ResourceGroup(resourceGroup, getButtonClass, multipage)
                             div(style="float:left")
                                 a.btn.btn-xs(class=btnClass, href="##{(multipage ? 'page:' + slug(resourceGroup.name) + ',header:' : '')}#{slug(resourceGroup.name)}-#{slug(resource.name)}-#{slug(action.method)}")= action.method
                             div(style="overflow:hidden")
-                                code= resource.uriTemplate
+                                code= action.attributes.uriTemplate || resource.uriTemplate
                         if action.description
                             .panel-body!= markdown(action.description)
 


### PR DESCRIPTION
An individual action should be able to  specify a different uriTemplate
then it's parent resource.

Specificiation, Action section
```## <identifier> [<HTTP request method> <URI template>]```

Fixes issue: #106