### PR TITLE
Allow to serve static files

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "moment": "^2.8.1",
     "protagonist": "^0.19.0",
     "remarkable": "^1.5.0",
+    "serve-static": "^1.9.3",
     "socket.io": "^1.0.6",
     "stylus": "~0.49.2",
     "yargs": "^1.3.1"

--- a/src/bin.coffee
+++ b/src/bin.coffee
@@ -4,6 +4,7 @@ clc = require 'cli-color'
 fs = require 'fs'
 http = require 'http'
 path = require 'path'
+serveStatic = require 'serve-static'
 parser = require('yargs')
     .usage('Usage: $0 [options] -i infile [-o outfile -s]')
     .example('$0 -i example.md -o output.html', 'Render to HTML')
@@ -79,7 +80,9 @@ exports.run = (argv=parser.argv, done=->) ->
 
         getHtml()
         server = http.createServer((req, res) ->
-            if req.url isnt '/' then return res.end()
+            if req.url isnt '/'
+                serve = serveStatic(path.dirname(argv.i))
+                return serve(req, res, () -> res.end())
 
             getHtml (err, html) ->
                 res.writeHead 200,


### PR DESCRIPTION
This pull-request adds support for #81.

Files present in the same directory as the input file will be served by the server.