### PR TITLE
work with synchronous olio-theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "markdown"
   ],
   "dependencies": {
-    "aglio-theme-olio": "0.0.3",
+    "aglio-theme-olio": "0.0.5",
     "chokidar": "^1.0.1",
     "cli-color": "^1.0.0",
     "drafter": "^0.2.7",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -100,15 +100,17 @@ exports.render = (input, options, done) ->
             options[name] ?= option.default
 
         benchmark.start 'render-total'
-        theme.render res.ast, options, (err, html) ->
-            benchmark.end 'render-total'
-            if err then return done(err)
+        try
+          html = theme.render res.ast, options
+        catch err
+          return done(err)
+        benchmark.end 'render-total'
 
-            # Add filtered input to warnings since we have no
-            # error to return
-            res.warnings.input = filteredInput
+        # Add filtered input to warnings since we have no
+        # error to return
+        res.warnings.input = filteredInput
 
-            done null, html, res.warnings
+        done null, html, res.warnings
 
 # Render from/to files
 exports.renderFile = (inputFile, outputFile, options, done) ->


### PR DESCRIPTION
Updates to be compatible with #113, pull after that one has been merged and released as `0.0.5`.