### PR TITLE
Use HTTPS URL on Google Fonts

### DIFF
--- a/styles/variables-cyborg.less
+++ b/styles/variables-cyborg.less
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200);
+@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');
 
 /* Page-wide variables */
 @padding: 12px;

--- a/styles/variables-default.less
+++ b/styles/variables-default.less
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200);
+@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');
 
 /* Page-wide variables */
 @padding: 12px;

--- a/styles/variables-flatly.less
+++ b/styles/variables-flatly.less
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200);
+@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');
 
 /* Page-wide variables */
 @padding: 12px;

--- a/styles/variables-slate.less
+++ b/styles/variables-slate.less
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200);
+@import url('https://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');
 
 /* Page-wide variables */
 @padding: 12px;


### PR DESCRIPTION
Since google fonts are available on SSL maybe use the
protocol-relative URL instead?

```css
@import url('//fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');
```

instead of:

```css
@import url('http://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200');
```