### PR TITLE
Should always move to next item in list.

### DIFF
--- a/src/schema.coffee
+++ b/src/schema.coffee
@@ -37,6 +37,7 @@ module.exports = renderSchema = (root, dataStructures) ->
       i = 0
       while i < properties.length
         member = properties[i]
+        i++
         if member.element == 'ref'
           ref = dataStructures[member.content.href]
           for item in ref.content
@@ -54,7 +55,6 @@ module.exports = renderSchema = (root, dataStructures) ->
           typeAttr = member.attributes.typeAttributes
           if typeAttr.indexOf('required') isnt -1
             required.push key
-        i++
       if required.length
         schema.required = required
     else


### PR DESCRIPTION
Our docs were hitting [this line](https://github.com/danielgtaylor/aglio/pull/189/files#diff-47aaba18a2e4c3d26a4c4a3ede463c4cR45) which was adding to properties and continuing the loop, without ever moving to the next item.