### PR TITLE
Display fixes

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -373,10 +373,11 @@ decorate = (api, md, slugCache, verbose) ->
         # Parameters may be defined on the action or on the
         # parent resource. Resource parameters should be concatenated
         # to the action-specific parameters if set.
-        if not action.parameters or not action.parameters.length
-          action.parameters = resource.parameters
-        else if resource.parameters
-          action.parameters = resource.parameters.concat(action.parameters)
+        if not (action.attributes or {}).uriTemplate
+          if not action.parameters or not action.parameters.length
+            action.parameters = resource.parameters
+          else if resource.parameters
+            action.parameters = resource.parameters.concat(action.parameters)
 
         # Remove any duplicates! This gives precedence to the parameters
         # defined on the action.

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -304,7 +304,7 @@ modifyUriTemplate = (templateUri, parameters, colorize) ->
             param = parameters[parameterNames.indexOf(
               querystring.unescape name.replace(/^\*|\*$/, ''))]
             "<span class=\"hljs-attribute\">#{name}=</span>" +
-              "<span class=\"hljs-literal\">#{param.example}</span>"
+              "<span class=\"hljs-literal\">#{param.example || ''}</span>"
           else
             "<span class=\"hljs-attribute\">#{name}</span>"
         ).join(if colorize then '&' else ',')


### PR DESCRIPTION
1. Don't display `undefined` in the Example URI when no `param.example` exists.
2. Don't include resource parameters for actions that have their own `uriTemplate`. This change is per [the spec](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#description-7):

  > URI parameters defined in the scope of a Resource section apply to *any and all* nested Action sections except when an URI template has been defined for the Action.