### PR TITLE
Render reserved

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -286,7 +286,7 @@ modifyUriTemplate = (templateUri, parameters, colorize) ->
     block.reservedSet = templateUri.indexOf("{+", index) is index
     lastIndex = closeIndex + 1
     index++
-    index++ if block.querySet
+    index++ if block.querySet or block.formSet or block.reservedSet
     parameterSet = templateUri.substring(index, closeIndex)
     block.parameters = parameterSet.split(",").filter(parameterValidator)
     parameterBlocks.push block if block.parameters.length
@@ -298,13 +298,13 @@ modifyUriTemplate = (templateUri, parameters, colorize) ->
       segment = if not colorize then ["{"] else []
       segment.push "?" if v.querySet
       segment.push "&" if v.formSet
-      segment.push "+" if v.reservedSet
+      segment.push "+" if v.reservedSet and not colorize
       segment.push v.parameters.map((name) ->
         if not colorize then name else
           # TODO: handle errors here?
-          param = parameters[parameterNames.indexOf(
-            querystring.unescape name.replace(/^\*|\*$/, ''))]
-          if v.querySet or v.formSet or v.reservedSet
+          name = name.replace(/^\*|\*$/, '')
+          param = parameters[parameterNames.indexOf(querystring.unescape name)]
+          if v.querySet or v.formSet
             "<span class=\"hljs-attribute\">#{name}=</span>" +
               "<span class=\"hljs-literal\">#{param.example || ''}</span>"
           else

--- a/test/uri.coffee
+++ b/test/uri.coffee
@@ -1,0 +1,137 @@
+{assert} = require 'chai'
+theme = require '../lib/main'
+
+examples = [
+  {
+    uriTemplate: '/resource/{path}'
+    parameters: [
+      {
+        name: 'path'
+      }
+    ]
+    exampleURI: [
+      '/resource/'
+      {attribute: 'path'}
+    ]
+  }
+
+  {
+    uriTemplate: '/resource/{+reserved}'
+    parameters: [
+      {
+        name: 'reserved'
+        example: 'this/that'
+      }
+    ]
+    exampleURI: [
+      '/resource/'
+      {attribute: 'this/that', title: 'reserved'}
+    ]
+  }
+
+  {
+    uriTemplate: '/resource{?greeting,name*}'
+    parameters: [
+      {
+        name: 'greeting'
+        example: 'hello'
+      }
+      {
+        name: 'name'
+        example: 'world'
+      }
+    ]
+    exampleURI: [
+      '/resource'
+      {operator: '?', attribute: 'greeting', literal: 'hello'}
+      {operator: '&', attribute: 'name', literal: 'world'}
+    ]
+  }
+
+  {
+    uriTemplate: '/resource{?greeting}{+something}'
+    parameters: [
+      {
+        name: 'greeting'
+        example: 'hello'
+      }
+      {
+        name: 'something'
+        example: 'with/slash'
+      }
+    ]
+    exampleURI: [
+      '/resource'
+      {operator: '?', attribute: 'greeting', literal: 'hello'}
+      {title: 'something', attribute: 'with/slash'}
+    ]
+  }
+]
+
+addParameterDefaults = (example) ->
+  example.parameters = for parameter in example.parameters
+    {
+      name: parameter.name
+      description: parameter.description or ''
+      type: parameter.type or 'string'
+      required: parameter.required or false
+      values: parameter.values or []
+      example: parameter.example or ''
+      defaultValue: parameter.defaultValue or ''
+    }
+
+generateAST = (example) ->
+  example.ast =
+    resourceGroups: [
+      name: 'TestGroup'
+      resources: [
+        name: 'TestResource'
+        uriTemplate: example.uriTemplate
+        parameters: example.parameters
+        actions: [
+          name: 'Test Action',
+          description: 'Test *description*'
+          method: 'GET'
+          parameters: []
+          examples: [
+            name: ''
+            description: ''
+            requests: [
+              name: '200'
+              headers: []
+              body: ''
+              schema: ''
+            ]
+            responses: []
+          ]
+        ]
+      ]
+    ]
+
+createExampleURI = (example) ->
+  exampleURI = ''
+  for segment in example.exampleURI
+    if typeof segment is 'string'
+      exampleURI += segment
+    else
+      if segment.operator
+        exampleURI += segment.operator
+      if segment.literal
+        exampleURI += "<span class=\"hljs-attribute\">#{segment.attribute}=</span><span class=\"hljs-literal\">#{segment.literal}</span>"
+      else
+        exampleURI += "<span class=\"hljs-attribute\" title=\"#{segment.title or segment.attribute}\">#{segment.attribute}</span>"
+  example.exampleURI = exampleURI
+
+
+describe 'URI Rendering', ->
+  examples.forEach (example) ->
+    addParameterDefaults example
+    generateAST example
+    createExampleURI example
+
+    it "Should render #{example.uriTemplate}", (done) ->
+      theme.render example.ast, (err, html) ->
+        if err then return done err
+        assert.include html, example.uriTemplate
+        assert.include html, example.exampleURI
+        done()

--- a/test/uri.coffee
+++ b/test/uri.coffee
@@ -49,6 +49,25 @@ examples = [
   }
 
   {
+    uriTemplate: '/resource{?greeting}{&name}'
+    parameters: [
+      {
+        name: 'greeting'
+        example: 'hello'
+      }
+      {
+        name: 'name'
+        example: 'world'
+      }
+    ]
+    exampleURI: [
+      '/resource'
+      {operator: '?', attribute: 'greeting', literal: 'hello'}
+      {operator: '&', attribute: 'name', literal: 'world'}
+    ]
+  }
+
+  {
     uriTemplate: '/resource{?greeting}{+something}'
     parameters: [
       {
@@ -132,6 +151,6 @@ describe 'URI Rendering', ->
     it "Should render #{example.uriTemplate}", (done) ->
       theme.render example.ast, (err, html) ->
         if err then return done err
-        assert.include html, example.uriTemplate
+        assert.include html, example.uriTemplate.replace /&/g, '&amp;'
         assert.include html, example.exampleURI
         done()


### PR DESCRIPTION
Example URIs don't always look how I'd expect. This improves the rendering of Example URI's for form (&) and reserved (+) parameters.

I also added a test for checking their output.