### PR TITLE
Including directive to require file remotely

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "protagonist": "^1.2.2",
     "serve-static": "^1.10.0",
     "socket.io": "^1.3.7",
-    "yargs": "^3.31.0"
+    "yargs": "^3.31.0",
+    "sync-request": "^3.0.0"
   },
   "devDependencies": {
     "async": "^1.5.0",

--- a/src/bin.coffee
+++ b/src/bin.coffee
@@ -22,6 +22,7 @@ parser = require('yargs')
     .options('v', alias: 'version', describe: 'Display version number', default: false)
     .options('c', alias: 'compile', describe: 'Compile the blueprint file', default: false)
     .options('n', alias: 'include-path', describe: 'Base directory for relative includes')
+    .options('H', alias: 'include-host', describe: 'Base host for relative includes')
     .options('verbose', describe: 'Show verbose information and stack traces', default: false)
     .epilog('See https://github.com/danielgtaylor/aglio#readme for more information')
 
@@ -146,7 +147,9 @@ exports.run = (argv=parser.argv, done=->) ->
             socket.on 'request-refresh', ->
                 sendHtml socket
 
-        paths = aglio.collectPathsSync fs.readFileSync(argv.i, 'utf-8'), path.dirname(argv.i)
+        paths = aglio.collectPathsSync fs.readFileSync(argv.i, 'utf-8'), {
+            includePath: path.dirname(argv.i),
+            includeHost: argv.includeHost }
 
         watcher = chokidar.watch [argv.i].concat(paths)
         watcher.on "change", (path) ->

--- a/src/include_directive.coffee
+++ b/src/include_directive.coffee
@@ -1,0 +1,58 @@
+fs = require 'fs'
+path = require 'path'
+request = require 'sync-request'
+
+INCLUDE_REGEX = /( *)<!-- include\((.*?)\)\s*(filesystem\((.*)\))?\s*-->/gmi
+
+# Replace the include directive with the contents of the included
+# file in the input.
+replaceText = (options, match, spaces, filename, filesystem, type) ->
+    if type == 'host'
+        content = readWebContent("#{options.includeHost}#{filename}", spaces)
+    else
+        fullPath = path.join options.includePath, filename
+        lines = fs.readFileSync(fullPath, 'utf-8').replace(/\r\n?/g, '\n').split('\n')
+        content = spaces + lines.join "\n#{spaces}"
+        options.includePath = path.dirname(fullPath)
+        # The content can itself include other files, so check those
+        # as well! Beware of circular includes!
+
+    this.replace content, options
+
+# Request web content
+readWebContent = (path, spaces) ->
+    spaces ?= '  '
+    try
+        response = request('GET', path)
+        if response.statusCode == 200
+            spaces + response.getBody()
+        else
+            ''
+    catch error
+        console.error "Invalid HTTP page #{path}"
+        ''
+
+# Handle the include directive, which inserts the contents of one
+# file into another. We find the directive using a regular expression
+# and replace it using the method above.
+exports.replace = (input, options) ->
+    input.replace INCLUDE_REGEX, replaceText.bind(this, options)
+
+# Get a list of all paths from included files. This *excludes* the
+# input path itself.
+exports.collectPathsSync = (input, options) ->
+    paths = []
+    input.replace INCLUDE_REGEX, (match, spaces, filename, filesystem, type) ->
+        if type == 'host'
+            fullPath = "#{options.includeHost}#{filename}"
+            paths.push fullPath
+            content = readWebContent(fullPath)
+            paths = paths.concat exports.collectPathsSync(content, options)
+
+        else
+            fullPath = path.join(options.includePath, filename)
+            paths.push fullPath
+
+            content = fs.readFileSync fullPath, 'utf-8'
+            paths = paths.concat exports.collectPathsSync(content, path.dirname(fullPath))
+    paths

--- a/test/basic.coffee
+++ b/test/basic.coffee
@@ -28,13 +28,28 @@ describe 'API Blueprint Renderer', ->
             More content...
         '''
 
-        paths = aglio.collectPathsSync input, '.'
+        paths = aglio.collectPathsSync input, { includePath: '.' }
 
         fs.readFileSync.restore()
 
         assert.equal paths.length, 2
         assert 'test1.apib' in paths
         assert 'test2.apib' in paths
+
+    it 'Should get a list of included files with host', ->
+
+        input = '''
+          host: http://localhost
+          # Title
+          <!-- include(/docs/test1.apib) filesystem(host) -->
+          Some content...
+          <!-- include(/test2.apib) filesystem(host) -->
+        '''
+        paths = aglio.collectPathsSync input, { includeHost: 'http://localhost' }
+
+        assert.equal paths.length, 2
+        assert 'http://localhost/docs/test1.apib' in paths
+        assert 'http://localhost/test2.apib' in paths
 
     it 'Should render blank string', (done) ->
         aglio.render '', template: 'default', locals: {foo: 1}, (err, html) ->
@@ -293,7 +308,9 @@ describe 'Executable', ->
             console.error.restore()
             assert err
 
-            bin.run i: path.join(root, 'example.apib'), s: true, p: 3000, h: 'localhost', (err) ->
+            file = path.join(root, 'example.apib')
+
+            bin.run i: file, s: true, p: 3000, h: 'localhost', (err) ->
                 assert.equal err, null
                 http.createServer.restore()
 


### PR DESCRIPTION
Requesting a content string that includes other files that are remote.

With this option, it's possible add directive
`<!-- include(/path/file.md) filesystem(host) -->`

And indicating to system where the remote file can be located
  Ex:
  `bin/aglio.js -i file.md -s -H http://localhost:3001`

**Motivation**:
Each API has your own markdown files and hosted together with your endpoints services

When a API has a lot of endpoints, the markdown file remain huge, so to simplify the included file, not locally but remotely, this PR was created.

Then a server to provide the documentation of all APIs can render the HTML files including all others markdown files remotely