### PR TITLE
Fixed Olio theme uri overlapping

### DIFF
--- a/styles/layout-default.less
+++ b/styles/layout-default.less
@@ -715,25 +715,24 @@ nav .resource-group{
     border-radius: @border-radius;
 
     h4.action-heading {
-        padding: @padding;
+        padding: @padding / 2 @padding;
         margin: -@padding -@padding @padding -@padding;
         border-bottom: 1px solid transparent;
         border-top-left-radius: @border-radius;
         border-top-right-radius: @border-radius;
-
-        white-space: nowrap;
-        text-overflow: ellipsis;
         overflow: hidden;
 
         .name {
             float: right;
             font-weight: normal;
+            padding: @padding / 2 0;
         }
 
         .method {
             padding: @padding / 2 @padding;
             margin-right: @padding;
             border-radius: ceil(@border-radius / 2);
+            display: inline-block;
 
             &.get {
                 color: contrast(@get-color);
@@ -776,6 +775,9 @@ nav .resource-group{
             background-color: @title-code-background-color;
             border-color: @title-code-border-color;
             font-weight: normal;
+            word-break: break-all;
+            display: inline-block;
+            margin-top: 2px;
         }
     }
 


### PR DESCRIPTION
With the current theme the URI overlaps the name as shown below. This pull request fixes the template so that when the URI is sufficiently long, it will render on the line below.

#### Before
<img width="689" alt="screen shot 2016-03-14 at 2 07 09 pm" src="https://cloud.githubusercontent.com/assets/177427/13751818/e0c8aa3c-e9ee-11e5-994d-b73d9a0ff896.png">

#### After

<img width="692" alt="screen shot 2016-03-14 at 2 16 02 pm" src="https://cloud.githubusercontent.com/assets/177427/13751910/4a12597a-e9ef-11e5-8aee-547e96ef030c.png">

It will also wrap sufficiently long URIs across multiple lines:

<img width="690" alt="screen shot 2016-03-14 at 2 17 14 pm" src="https://cloud.githubusercontent.com/assets/177427/13751959/86307860-e9ef-11e5-82d8-4e90e4197861.png">

Shorter URIs are still rendered adjacent to the method.

<img width="689" alt="screen shot 2016-03-14 at 2 18 37 pm" src="https://cloud.githubusercontent.com/assets/177427/13752017/c25082c2-e9ef-11e5-9b26-b05e8de48cfa.png">

This should also fix the problem referenced in #198.