### PR TITLE
Bump protagonist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chokidar": "^1.4.1",
     "cli-color": "^1.1.0",
     "pretty-error": "^1.2.0",
-    "protagonist": "^1.2.2",
+    "protagonist": "^1.3.2",
     "serve-static": "^1.10.0",
     "socket.io": "^1.3.7",
     "yargs": "^3.31.0"


### PR DESCRIPTION
@danielgtaylor the old version of protagonist had some bugs when using `Data Structures`. Updating the version of this library to 1.3.2 helped a lot. Would be nice if you could merge this pull request and release a new version.