### PR TITLE
Fix case when nothing is passed to "-o" arg

### DIFF
--- a/src/bin.coffee
+++ b/src/bin.coffee
@@ -161,7 +161,7 @@ exports.run = (argv=parser.argv, done=->) ->
             parser.showHelp()
             return done 'Invalid arguments'
 
-        if argv.c or argv.o.match /\.apib$/ or argv.o.match /\.md$/
+        if argv.c or (typeof argv.o is 'string' and (argv.o.match /\.apib$/ or argv.o.match /\.md$/))
             aglio.compileFile argv.i, argv.o, (err) ->
                 if (err)
                     logError err, argv.verbose


### PR DESCRIPTION
# Fix case when nothing is passed to "-o" arg


## Before

* Input: `aglio -i /path/to/api -o`
* Output:
```
/usr/local/lib/node_modules/aglio/lib/bin.js:228
      if (argv.c || argv.o.match(/\.apib$/ || argv.o.match(/\.md$/))) {
                           ^

TypeError: argv.o.match is not a function
    at Object.exports.run (/usr/local/lib/node_modules/aglio/lib/bin.js:228:28)
    at Object.<anonymous> (/usr/local/lib/node_modules/aglio/bin/aglio.js:5:23)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:140:18)
    at node.js:1001:3
```

## After

* Input: `aglio -i /path/to/api -o`
* Output:
```
>> [TypeError: Could not get template: Error loading cached resource: path must be a string]
```