### PR TITLE
allow for theme packages that dont start with aglio-theme

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -53,7 +53,7 @@ exports.collectPathsSync = (input, includePath) ->
 exports.getTheme = (name) ->
     name = 'olio' if not name or name in LEGACY_TEMPLATES
     try
-    	  require "aglio-theme-#{name}"
+        require "aglio-theme-#{name}"
     catch err
         require name
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -52,7 +52,10 @@ exports.collectPathsSync = (input, includePath) ->
 # Get the theme module for a given theme name
 exports.getTheme = (name) ->
     name = 'olio' if not name or name in LEGACY_TEMPLATES
-    require "aglio-theme-#{name}"
+    try
+    	  require "aglio-theme-#{name}"
+    catch err
+        require name
 
 # Render an API Blueprint string using a given template
 exports.render = (input, options, done) ->


### PR DESCRIPTION
this allows 2 use cases
- private npm packages to be used e.g. @username/aglio-theme-name
- themes that don't have the aglio-theme- prefix
