### PR TITLE
Use Drafter NPM Package for API Blueprint Parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chokidar": "^1.4.1",
     "cli-color": "^1.1.0",
     "pretty-error": "^1.2.0",
-    "protagonist": "^1.3.2",
+    "drafter": "^1.0.0",
     "serve-static": "^1.10.0",
     "socket.io": "^1.3.7",
     "yargs": "^3.31.0"

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs'
 path = require 'path'
-protagonist = require 'protagonist'
+drafter = require 'drafter'
 
 INCLUDE = /( *)<!-- include\((.*)\) -->/gmi
 ROOT = path.dirname __dirname
@@ -82,7 +82,7 @@ exports.render = (input, options, done) ->
     # Handle custom directive(s)
     input = includeDirective options.includePath, input
 
-    # Protagonist does not support \r ot \t in the input, so
+    # Drafter does not support \r ot \t in the input, so
     # try to intelligently massage the input so that it works.
     # This is required to process files created on Windows.
     filteredInput = if not options.filterInput then input else
@@ -91,7 +91,7 @@ exports.render = (input, options, done) ->
             .replace(/\t/g, '    ')
 
     benchmark.start 'parse'
-    protagonist.parse filteredInput, type: 'ast', (err, res) ->
+    drafter.parse filteredInput, type: 'ast', (err, res) ->
         benchmark.end 'parse'
         if err
             err.input = input

--- a/test/basic.coffee
+++ b/test/basic.coffee
@@ -4,7 +4,7 @@ bin = require '../lib/bin'
 fs = require 'fs'
 http = require 'http'
 path = require 'path'
-protagonist = require 'protagonist'
+drafter = require 'drafter'
 sinon = require 'sinon'
 
 root = path.dirname(__dirname)
@@ -164,13 +164,13 @@ describe 'API Blueprint Renderer', ->
             done()
 
     it 'Should error on drafter failure', (done) ->
-        sinon.stub protagonist, 'parse', (content, options, callback) ->
+        sinon.stub drafter, 'parse', (content, options, callback) ->
             callback 'error'
 
         aglio.render blueprint, 'default', (err, html) ->
             assert err
 
-            protagonist.parse.restore()
+            drafter.parse.restore()
 
             done()
 


### PR DESCRIPTION
This should make installing Aglio simpler. Drafter NPM package optionally depends on the C++ API Blueprint Parser (Protagonist) and uses a pure JS version if it cannot be installed. If Protagonist cannot be installed, users will still be able to install and use Aglio with the pure JS parser.

See [Drafter NPM](https://github.com/apiaryio/drafter-npm) for more details.

Closes #246
Closes #249
Closes #264
Closes #201