### PR TITLE
Bump protagonist version to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chokidar": "^1.4.1",
     "cli-color": "^1.1.0",
     "pretty-error": "^1.2.0",
-    "protagonist": "^1.3.2",
+    "protagonist": "^1.5.0",
     "serve-static": "^1.10.0",
     "socket.io": "^1.3.7",
     "yargs": "^3.31.0"


### PR DESCRIPTION
new protagonist uses drafter 3.1.0 with several enhancements
https://github.com/apiaryio/drafter/releases/tag/v3.1.0
https://github.com/apiaryio/drafter/releases/tag/v3.1.0-pre.0