### PR TITLE
Fix undefined variable

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -169,7 +169,7 @@ getCss = (variables, styles, verbose, done) ->
 
     benchmark.start 'less-compile'
     less.render tmp, compress: true, (err, result) ->
-      if err then return done(msgErr 'Error processing LESS -> CSS', err)
+      if err then return done(errMsg 'Error processing LESS -> CSS', err)
 
       try
         css = result.css


### PR DESCRIPTION
There is a wrong variable name in the script for, which throws an Error when something with the Less Compiling goes wrong. I fixed the name from `msgErr` to `errMsg`.
