### PR TITLE
Release 2.3.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# 2.3.0
+
+* Switch to [Drafter](https://github.com/apiaryio/drafter-npm) for API Blueprint parsing. [#277](https://github.com/danielgtaylor/aglio/pull/277)
+* Fix case when no arguments are supplied after `-o` [#262](https://github.com/danielgtaylor/aglio/pull/262)
+
 # 2.2.1 - 2016-05-20
 
 * Bump protagonist version to 1.3.2 to support new features. [#256](https://github.com/danielgtaylor/aglio/pull/256)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aglio",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "An API Blueprint renderer with theme support",
   "main": "lib/main.js",
   "bin": {


### PR DESCRIPTION
To get https://github.com/danielgtaylor/aglio/pull/277 out, we should make a release which should help a lot of users install Agilo and get on a more modern API Blueprint parser.

@danielgtaylor Any chance you would be able to merge this and `npm publish`? I'm happy to help if there is anything I can do.