### PR TITLE
Add quiet flag to suppress warning messages

### DIFF
--- a/src/bin.coffee
+++ b/src/bin.coffee
@@ -22,6 +22,7 @@ parser = require('yargs')
     .options('v', alias: 'version', describe: 'Display version number', default: false)
     .options('c', alias: 'compile', describe: 'Compile the blueprint file', default: false)
     .options('n', alias: 'include-path', describe: 'Base directory for relative includes')
+    .options('q', alias: 'quiet', boolean: true, describe: 'Suppress warning messages', default: false)
     .options('verbose', describe: 'Show verbose information and stack traces', default: false)
     .epilog('See https://github.com/danielgtaylor/aglio#readme for more information')
 
@@ -46,12 +47,13 @@ getLineNo = (input, err) ->
 
 # Output warning info
 logWarnings = (warnings) ->
-    for warning in warnings or []
-        lineNo = getLineNo(warnings.input, warning) or 0
-        errContext = getErrContext(warnings.input, lineNo)
-        console.error cWarn(">> Line #{lineNo}:") + " #{warning.message} (warning code #{warning.code})"
-        console.error cWarn(">> Context")
-        console.error "       ...\n #{errContext.join('\n')} \n       ..."
+    if !parser.argv.quiet
+        for warning in warnings or []
+            lineNo = getLineNo(warnings.input, warning) or 0
+            errContext = getErrContext(warnings.input, lineNo)
+            console.error cWarn(">> Line #{lineNo}:") + " #{warning.message} (warning code #{warning.code})"
+            console.error cWarn(">> Context")
+            console.error "       ...\n #{errContext.join('\n')} \n       ..."
 
 # Output an error message
 logError = (err, verbose) ->


### PR DESCRIPTION
Add a quiet flag, as `-q` with alias `--quiet`, which suppresses warning messages when set. This is requested in #280.

My test plan was:
1. Modify `example.apib` to throw a warning and run `./bin/aglio -i example.apib -o out.html` to confirm that a warning is outputted.
2. Run `./bin/aglio -i example.apib -o out.html -q` and confirm that no warnings are displayed.
3. Run `./bin/aglio -i example.apib -o out.html --quiet` and confirm that no warnings are displayed.
4. Run unit tests with `grunt test` and confirm all tests still pass.