### PR TITLE
Add option to chokidar watcher to prevent empty documents upon live reload

### DIFF
--- a/src/bin.coffee
+++ b/src/bin.coffee
@@ -148,7 +148,7 @@ exports.run = (argv=parser.argv, done=->) ->
 
         paths = aglio.collectPathsSync fs.readFileSync(argv.i, 'utf-8'), path.dirname(argv.i)
 
-        watcher = chokidar.watch [argv.i].concat(paths)
+        watcher = chokidar.watch [argv.i].concat(paths), awaitWriteFinish: true
         watcher.on "change", (path) ->
             console.log "Updated " + path
             _html = null


### PR DESCRIPTION
This fixes #239 

See the documentation of [chokidar](https://github.com/paulmillr/chokidar) on `awaitWriteFinish` for more details.