### PR TITLE
Support "try it out" requests to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Name           | Description
 `style`        | LESS or CSS to control the layout and style of the document using the variables from below. Can be a path to your own file or one of the following presets: `default`. May be an array of paths and/or presets.
 `template`     | Jade template to render HTML. Can be a path to your own file or one of the following presets: `default`.
 `variables`    | LESS variables that control theme colors, fonts, and spacing. Can be a path to your own file or one of the following presets: `default`, `flatly`, `slate`, `cyborg`. May be an array of paths and/or presets.
+`forms`        | Whether to generate form fields for trying out the API (default is `false`).
+`forms-base-uri` | The base URI to prepend to relative action URIs when trying out the API. Default is `auto`, meaning the full URI is calculated from the HOST keyword in the API Blueprint document or when that isn't present, from the host serving the documentation.
 
 **Note**: When using this theme programmatically, these options are cased like you would expect in Javascript: `--theme-full-width` becomes `options.themeFullWidth`.
 

--- a/styles/layout-default.less
+++ b/styles/layout-default.less
@@ -121,6 +121,7 @@ pre {
     border: 1px solid @code-block-border-color;
     border-radius: @border-radius;
     overflow: auto;
+    max-height: 50em;
 
     code {
         color: @code-block-text-color;
@@ -137,6 +138,34 @@ code {
     padding: 1px 4px;
     border: 1px solid @code-block-border-color;
     border-radius: 3px;
+}
+
+input.parameter, select.parameter, select.request {
+    width: 200px;
+}
+
+textarea.body {
+    width: 300px;
+    height: 100px;
+}
+
+button.tryit {
+    padding: 1px 4px;
+    font: inherit;
+    margin: 12px 0 12px 150px;
+}
+
+.spinner {
+    margin-left: 4px;
+    display: none;
+}
+
+.response {
+    display: none;
+}
+
+.click-to-fill {
+    cursor: pointer;
 }
 
 ul, ol {
@@ -389,6 +418,10 @@ nav {
     max-height: 0;
     overflow: hidden;
     transition: max-height 0.3s ease-in-out;
+
+    dd {
+        overflow: auto;
+    }
 }
 
 /* Layout classes */

--- a/templates/index.jade
+++ b/templates/index.jade
@@ -5,6 +5,7 @@ include mixins.jade
 html
     head
         meta(charset="utf-8")
+        meta(http-equiv="X-UA-Compatible", content="IE=edge")
         title= self.api.name || 'API Documentation'
         link(rel="stylesheet", href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css")
         style!= self.css

--- a/templates/mixins.jade
+++ b/templates/mixins.jade
@@ -63,7 +63,7 @@ mixin Nav()
                 p(style="text-align: center; word-wrap: break-word;")
                     a(href=meta.value)= meta.value
 
-mixin Parameters(params)
+mixin Parameters(action)
     //- Draw a definition list of parameter names, types, defaults,
     //- examples and descriptions.
     .title
@@ -72,9 +72,11 @@ mixin Parameters(params)
             span.close Hide
             span.open Show
     .collapse-content
-        dl.inner: each param in params || []
+        dl.inner: each param in action.parameters || []
             dt= self.urldec(param.name)
             dd
+                if self.forms
+                    +ParameterField(param, action)
                 code= param.type || 'string'
                 | &nbsp;
                 if param.required
@@ -90,16 +92,124 @@ mixin Parameters(params)
                 if param.example
                     span.text-muted.example
                         strong Example:&nbsp;
-                        span= param.example
+                        span(
+                            class={'click-to-fill': self.forms}
+                            data-fill-target=self.urldec(action.elementId + '-' + param.name)
+                        )
+                            = param.example
                 != self.markdown(param.description)
                 if param.values.length
                     p.choices
                         strong Choices:&nbsp;
                         each value in param.values
-                            code= self.urldec(value.value)
+                            code(
+                                class={'click-to-fill': self.forms}
+                                data-fill-target=self.urldec(action.elementId + '-' + param.name)
+                            )
+                                = self.urldec(value.value)
                             = ' '
 
-mixin RequestResponse(title, request, collapse)
+mixin ParameterField(param, action)
+    //- Generate an input field for the parameter to use
+    - var values = param.type === 'boolean' ? [{value: 'true'}, {value: 'false'}] : param.values
+    - values = (values && values.length) ? values : undefined
+    if values
+        select.parameter(
+            name=self.urldec(param.name)
+            id=action.elementId + '-' + param.name
+            required=param.required
+            multiple=param.explode
+        )
+            unless param.required
+                option
+            each option in values || []
+                option(
+                    value=option.value
+                    selected=option.value === param.default
+                )
+                    = option.value
+    else
+        - var type = param.type === 'number' ? 'number' : 'text'
+        - var value = param.required ? param.default || param.example || '' : ''
+        input.parameter(
+            type=type
+            name=self.urldec(param.name)
+            id=action.elementId + '-' + param.name
+            value=value
+            required=param.required
+        )
+
+mixin FormFields(action)
+    input(
+        type='hidden'
+        name='__method'
+        value=action.method
+    )
+    input(
+        type='hidden'
+        name='__uri'
+        value=action.fullUriTemplate
+    )
+    - var body
+    each example in action.examples
+        each request, index in example.requests
+            - body = body || request.body
+            each item in request.headers
+                input(
+                    type='hidden'
+                    name='__' + index + '-header_' + item.name
+                    value=item.value
+                )
+    +RequestIndexField(action)
+    if action.hasBody
+        dl.inner
+            dt Body
+            dd
+                textarea.body(
+                    name='__body'
+                    id=action.elementId + '-__body'
+                )= body
+
+mixin RequestIndexField(action)
+    if action.requestCount <= 1
+        input(
+            type='hidden'
+            name='__request'
+            value='0'
+        )
+    else
+        - var requestIndex = 0
+        dl.inner
+            dt Request
+            dd
+                select.request(name='__request')
+                    each example in action.examples
+                        each request in example.requests
+                            option(
+                                value=requestIndex
+                            )= request.name || request.description || 'Request ' + (requestIndex + 1)
+                            - requestIndex++
+
+mixin FormAction
+    button.tryit(name='__tryit', type='button') Try it out!
+        span.spinner: i.fa.fa-spinner.fa-pulse
+
+    .response.title
+        strong Server Response
+        .collapse-button.show
+            span.close Hide
+            span.open Show
+    .response.collapse-content
+        .inner
+            +FormResponseSection('Request URI', 'response-request-uri')
+            +FormResponseSection('Response Body', 'response-body')
+            +FormResponseSection('Response Headers', 'response-headers')
+
+mixin FormResponseSection(title, cls)
+        h5= title
+        pre: code(class=cls)
+
+mixin RequestResponse(title, action, request, collapse, clickToFill)
     .title
         strong
             = title
@@ -110,9 +220,9 @@ mixin RequestResponse(title, request, collapse)
             .collapse-button
                 span.close Hide
                 span.open Show
-    +RequestResponseBody(request, collapse)
+    +RequestResponseBody(action, request, collapse, clickToFill)
 
-mixin RequestResponseBody(request, collapse, showBlank)
+mixin RequestResponseBody(action, request, collapse, clickToFill, showBlank)
     if request.hasContent || showBlank
         div(class=collapse ? 'collapse-content' : ''): .inner
             if request.description
@@ -128,8 +238,12 @@ mixin RequestResponseBody(request, collapse, showBlank)
                 div(style="height: 1px;")
             if request.body
                 h5 Body
-                pre: code
-                    != self.highlight(request.body, null, ['json', 'yaml', 'xml', 'javascript'])
+                pre(
+                    class={'click-to-fill': self.forms && clickToFill}
+                    data-fill-target=action.elementId + '-__body'
+                )
+                    code
+                        != self.highlight(request.body, null, ['json', 'yaml', 'xml', 'javascript'])
                 div(style="height: 1px;")
             if request.schema
                 h5 Schema
@@ -143,9 +257,9 @@ mixin RequestResponseBody(request, collapse, showBlank)
 mixin Examples(resourceGroup, resource, action)
     each example in action.examples
         each request in example.requests
-            +RequestResponse('Request', request, true)
+            +RequestResponse('Request', action, request, true, true)
         each response in example.responses
-            +RequestResponse('Response', response, true)
+            +RequestResponse('Response', action, response, true)
 
 mixin Content()
     //- Page header and API description
@@ -195,10 +309,15 @@ mixin Content()
 
                             //- A list of sub-sections for parameters, requests
                             //- and responses.
-                            if action.parameters.length
-                                +Parameters(action.parameters)
-                            if action.examples
-                                +Examples(resourceGroup, resource, action)
+                            form(accept-charset='UTF-8')
+                                if action.parameters.length
+                                    +Parameters(action)
+                                if self.forms
+                                    +FormFields(action)
+                                if self.forms
+                                    +FormAction
+                                if action.examples
+                                    +Examples(resourceGroup, resource, action)
 
 mixin ContentTriple()
     .middle
@@ -245,7 +364,7 @@ mixin ContentTriple()
                             span.hostname= self.api.host
                             != action.colorizedUriTemplate
                       .tabs
-                          if action.hasRequest
+                          if action.requestCount > 0
                               .example-names
                                   span Requests
                                   - var requestCount = 0
@@ -256,7 +375,7 @@ mixin ContentTriple()
                               each example in action.examples
                                   each request in example.requests
                                       .tab
-                                          +RequestResponseBody(request, false, true)
+                                          +RequestResponseBody(action, request, false, true, true)
                                           .tabs
                                               .example-names
                                                   span Responses
@@ -264,7 +383,7 @@ mixin ContentTriple()
                                                       span.tab-button= response.name
                                               each response in example.responses
                                                   .tab
-                                                      +RequestResponseBody(response, false, true)
+                                                      +RequestResponseBody(action, response, false, false, true)
                           else
                             each example in action.examples
                                 .tabs
@@ -274,7 +393,7 @@ mixin ContentTriple()
                                             span.tab-button= response.name
                                     each response in example.responses
                                         .tab
-                                            +RequestResponseBody(response, false, true)
+                                            +RequestResponseBody(action, response, false, false, true)
                 .middle
                     .action(class=action.methodLower, id=action.elementId)
                         h4.action-heading
@@ -287,7 +406,11 @@ mixin ContentTriple()
 
                         //- A list of sub-sections for parameters, requests
                         //- and responses.
-                        if action.parameters.length
-                            +Parameters(action.parameters)
+                        form(accept-charset='UTF-8')
+                            if action.parameters.length
+                                +Parameters(action)
+                            if self.forms
+                                +FormFields(action)
+                                +FormAction
 
                 hr.split

--- a/test/forms.coffee
+++ b/test/forms.coffee
@@ -1,0 +1,372 @@
+{assert} = require 'chai'
+theme = require '../lib/main'
+
+describe 'Forms', ->
+  it 'Should not generate form fields when disabled', (done) ->
+
+    theme.render ast, {themeForms: false}, (err, html) ->
+      if err then return done err
+
+      assert.notInclude html, '<input'
+      assert.notInclude html, '<select'
+      assert.notInclude html, '<textarea'
+      assert.notInclude html, 'Try it out!'
+      assert.notInclude html, 'class="click-to-fill"'
+
+      done()
+
+  it 'Should use the formsBaseUri option', (done) ->
+
+    theme.render ast, {themeForms: true, themeFormsBaseUri: 'http://example.com/rest/'}, (err, html) ->
+      if err then return done err
+      assert.include html, '<input type="hidden" name="__uri" value="http://example.com/rest/test">'
+      done()
+
+  it 'Should use the HOST metadata when there is no formsBaseUri option', (done) ->
+
+    theme.render ast, {themeForms: true}, (err, html) ->
+      if err then return done err
+      assert.include html, '<input type="hidden" name="__uri" value="http://acme.com/test">'
+      done()
+
+  it 'Should generate form fields', (done) ->
+
+    theme.render ast, {themeForms: true}, (err, html) ->
+      if err then return done err
+
+      # GET
+
+      expectSelect html, 'boolean', true, ['true', 'false']
+      expectClickToFill html, 'boolean', 'true'
+
+      expectSelect html, 'optional_boolean', false, ['', 'true', 'false']
+      expectClickToFill html, 'optional_boolean', 'true'
+
+      expectInput html, 'number', 'number', true, 123
+      expectClickToFill html, 'number', 123
+
+      expectInput html, 'optional', 'text'
+      expectClickToFill html, 'optional', 'example'
+
+      expectInput html, 'default', 'text', true, 'default'
+      expectNoClickToFill html, 'default'
+
+      expectInput html, 'example', 'text', true, 'example'
+      expectClickToFill html, 'example', 'example'
+
+      expectInput html, 'default_example', 'text', true, 'default'
+      expectClickToFill html, 'default_example', 'example'
+
+      expectSelect html, 'enum', true, ['one', 'two']
+      expectClickToFill html, 'enum', 'one', 'code'
+      expectClickToFill html, 'enum', 'two', 'code'
+      expectClickToFill html, 'enum', 'two'
+
+      expectSelect html, 'optional_enum', false, ['', 'one', 'two']
+      expectClickToFill html, 'optional_enum', 'one', 'code'
+      expectClickToFill html, 'optional_enum', 'two', 'code'
+      expectClickToFill html, 'optional_enum', 'two'
+
+      expectSelect html, 'explode_enum', true, ['one', 'two'], true
+      expectClickToFill html, 'explode_enum', 'one', 'code'
+      expectClickToFill html, 'explode_enum', 'two', 'code'
+      expectClickToFill html, 'explode_enum', 'one'
+
+      # POST
+
+      assert.include html, '<select name="__request" class="request"><option value="0">Text Message</option><option value="1">JSON Message</option></select>'
+      assert.include html, '<textarea name="__body" id="test-post-__body" class="body">Dave\n</textarea>'
+
+      done()
+
+
+expectSelect = (html, name, required, options, multiple) ->
+  required = if required then ' required' else ''
+  multiple = if multiple then ' multiple' else ''
+  assert.include html, "<select name=\"#{name}\" id=\"test-get-#{name}\"#{required}#{multiple} class=\"parameter\">#{createOptions options}</select>"
+
+createOptions = (options) ->
+  result = ''
+  for option in options
+    if option
+      result += "<option value=\"#{option}\">#{option}</option>"
+    else
+      result += "<option></option>"
+  return result
+
+expectInput = (html, name, type, required, value) ->
+  required = if required then ' required' else ''
+  assert.include html, "<input type=\"#{type || 'text'}\" name=\"#{name}\" id=\"test-get-#{name}\" value=\"#{value || ''}\"#{required} class=\"parameter\">"
+
+expectClickToFill = (html, name, example, tag) ->
+  tag ?= 'span'
+  assert.include html, "<#{tag} data-fill-target=\"test-get-#{name}\" class=\"click-to-fill\">#{example}</#{tag}>"
+
+expectNoClickToFill = (html, name) ->
+  assert.notInclude html, "<span data-fill-target=\"test-get-#{name}\""
+
+
+ast = {
+  metadata: [
+    {
+      name: 'HOST',
+      value: 'http://acme.com'
+    }
+  ]
+  name: ''
+  description: ''
+  resourceGroups: [
+    {
+      name: ''
+      description: ''
+      resources: [
+        {
+          name: 'Test'
+          description: ''
+          uriTemplate: '/test'
+          model: {}
+          parameters: []
+          actions: [
+            {
+              name: 'Retrieve'
+              description: 'Test get.\n\n'
+              method: 'GET'
+              parameters: [
+                {
+                  name: 'boolean'
+                  description: 'A boolean parameter'
+                  type: 'boolean'
+                  required: true
+                  default: ''
+                  example: 'true'
+                  values: []
+                }
+                {
+                  name: 'optional_boolean'
+                  description: 'A boolean parameter'
+                  type: 'boolean'
+                  required: false
+                  default: ''
+                  example: 'true'
+                  values: []
+                }
+                {
+                  name: 'number'
+                  description: 'A number parameter'
+                  type: 'number'
+                  required: true
+                  default: ''
+                  example: '123'
+                  values: []
+                }
+                {
+                  name: 'optional'
+                  description: 'An optional string parameter with an example'
+                  type: 'string'
+                  required: false
+                  default: ''
+                  example: 'example'
+                  values: []
+                }
+                {
+                  name: 'default'
+                  description: 'A string parameter with a default value but no example'
+                  type: 'string'
+                  required: true
+                  default: 'default'
+                  example: ''
+                  values: []
+                }
+                {
+                  name: 'example'
+                  description: 'A string parameter with an example but no default'
+                  type: 'string'
+                  required: true
+                  default: ''
+                  example: 'example'
+                  values: []
+                }
+                {
+                  name: 'default_example'
+                  description: 'A string parameter with an example and a default'
+                  type: 'string'
+                  required: true
+                  default: 'default'
+                  example: 'example'
+                  values: []
+                }
+                {
+                  name: 'enum'
+                  description: 'An enum parameter'
+                  type: 'string'
+                  required: true
+                  default: ''
+                  example: 'two'
+                  values: [
+                    { value: 'one' }
+                    { value: 'two' }
+                  ]
+                }
+                {
+                  name: 'optional_enum'
+                  description: 'An optional enum parameter'
+                  type: 'string'
+                  required: false
+                  default: ''
+                  example: 'two'
+                  values: [
+                    { value: 'one' }
+                    { value: 'two' }
+                  ]
+                }
+                {
+                  name: 'explode_enum'
+                  description: 'An explosive enum parameter'
+                  type: 'string'
+                  required: true
+                  default: ''
+                  example: 'one'
+                  values: [
+                    { value: 'one' }
+                    { value: 'two' }
+                  ]
+                }
+              ]
+              attributes:
+                relation: ''
+                uriTemplate: '/test{?resource}{&boolean}{&optional_boolean}{&number}{&optional}{&default}{&example}{&default_example}{&enum}{&optional_enum}{&explode_enum*}'
+              content: []
+              examples: [
+                {
+                  name: ''
+                  description: ''
+                  requests: []
+                  responses: [
+                    {
+                      name: '200'
+                      description: ''
+                      headers: [
+                        {
+                          name: 'Content-Type'
+                          value: 'application/json'
+                        }
+                      ]
+                      body: ''
+                      schema: ''
+                      content: []
+                    }
+                  ]
+                }
+              ]
+            }
+            {
+              name: 'Post'
+              description: 'Test post.\n\n'
+              method: 'POST'
+              parameters: []
+              attributes:
+                relation: ''
+                uriTemplate: ''
+              content: []
+              examples: [
+                {
+                  name: ''
+                  description: ''
+                  requests: [
+                    {
+                      name: 'Text Message'
+                      description: ''
+                      headers: [
+                        {
+                          name: 'Content-Type'
+                          value: 'text/plain'
+                        }
+                      ]
+                      body: 'Dave\n'
+                      schema: ''
+                      content: [
+                        {
+                          attributes:
+                            role: 'bodyExample'
+                          content: 'Dave\n'
+                        }
+                      ]
+                    }
+                  ]
+                  responses: [
+                    {
+                      name: '200'
+                      description: ''
+                      headers: [
+                        {
+                          name: 'Content-Type'
+                          value: 'text/plain'
+                        }
+                      ]
+                      body: 'Hello Dave\n'
+                      schema: ''
+                      content: [
+                        {
+                          attributes:
+                            role: 'bodyExample'
+                          content: 'Hello Dave\n'
+                        }
+                      ]
+                    }
+                  ]
+                }
+                {
+                  name: ''
+                  description: ''
+                  requests: [
+                    {
+                      name: 'JSON Message'
+                      description: ''
+                      headers: [
+                        {
+                          name: 'Content-Type'
+                          value: 'application/json'
+                        }
+                      ]
+                      body: '{\n    \'name\': \'Dave\',\n    \'greeting\': \'Hi\'\n}\n'
+                      schema: ''
+                      content: [
+                        {
+                          attributes:
+                            role: 'bodyExample'
+                          content: '{\n    \'name\': \'Dave\',\n    \'greeting\': \'Hi\'\n}\n'
+                        }
+                      ]
+                    }
+                  ]
+                  responses: [
+                    {
+                      name: '200'
+                      description: ''
+                      headers: [
+                        {
+                          name: 'Content-Type'
+                          value: 'application/json'
+                        }
+                      ]
+                      body: '{\n    \'message\': \'Hi Dave\'\n}\n'
+                      schema: ''
+                      content: [
+                        {
+                          attributes:
+                            role: 'bodyExample'
+                          content: '{\n    \'message\': \'Hi Dave\'\n}\n'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+          content: []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A company project needed support for "try it out" functionality, where you can enter values into form fields, press a button to send the request to the server and display the response. The changes have now been [open-sourced](http://code.osehra.org/journal/journal/view/1116), and here they are.

This functionality doesn't appear by default, but can be enabled with the `forms` option.